### PR TITLE
updating thumbnail path in species search to fetch thumbnail correctly from published APIs or direct server access

### DIFF
--- a/grails-app/views/species/search.gsp
+++ b/grails-app/views/species/search.gsp
@@ -249,7 +249,7 @@
                                 <g:if test="${result.image}">
                                     <div class="result-thumbnail">
                                         <a href="${acceptedPageLink}">
-                                            <img src="${grailsApplication.config.image.thumbnailUrl}${result.image}" alt="">
+                                            <img src="${grailsApplication.config.image.thumbnailUrl}${result.image}/thumbnail" alt="">
                                         </a>
                                     </div>
                                 </g:if>
@@ -274,7 +274,7 @@
                                 <g:if test="${result.image}">
                                     <div class="result-thumbnail">
                                         <a href="${speciesPageLink}">
-                                            <img src="${grailsApplication.config.image.thumbnailUrl}${result.image}" alt="">
+                                            <img src="${grailsApplication.config.image.thumbnailUrl}${result.image}/thumbnail" alt="">
                                         </a>
                                     </div>
                                 </g:if>


### PR DESCRIPTION
Resolves #65 
 - Fix missing thumbnail on species search