### PR TITLE
issue #69 updating distribution map url to read from either distribution.imageUrl or distribution.image_url

### DIFF
--- a/grails-app/assets/javascripts/species.show.js
+++ b/grails-app/assets/javascripts/species.show.js
@@ -877,7 +877,7 @@ function loadExpertDistroMap() {
         if (data) {
             $.each(data, function (idx, distribution) {
                 var record = {
-                    url: distribution.imageUrl,
+                    url: distribution.imageUrl || distribution.image_url,
                     name: distribution.area_name,
                     dr: distribution.data_resource_uid
                 }


### PR DESCRIPTION
Hotfix patch to resolve #69 