### PR TITLE
#124 Add custom user-agent header to service requests

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -249,6 +249,8 @@ vernacularName:
         showLanguage: false
 external:
     blacklist: file:./src/test/resources/test-blacklist.json
+
+customUserAgent: 'ala-bie-hub/${info.app.version}'
 ---
 #headerAndFooter:
 #    baseURL: "https://www.ala.org.au/commonui-bs3-2019"

--- a/grails-app/services/au/org/ala/bie/WebClientService.groovy
+++ b/grails-app/services/au/org/ala/bie/WebClientService.groovy
@@ -22,6 +22,7 @@ import org.grails.web.converters.exceptions.ConverterException
 import org.springframework.beans.factory.InitializingBean
 
 class WebClientService implements InitializingBean {
+    def grailsApplication
 
     public void afterPropertiesSet() {
         // JSONObject.NULL.metaClass.asBoolean = {-> false}
@@ -39,6 +40,7 @@ class WebClientService implements InitializingBean {
             }
             conn.setConnectTimeout(10000)
             conn.setReadTimeout(50000)
+            conn.setRequestProperty('User-Agent', grailsApplication.config.getProperty("customUserAgent", "ala-bie-hub"))
             return conn.content.text
         } catch (SocketTimeoutException e) {
             if(throwError)
@@ -67,6 +69,7 @@ class WebClientService implements InitializingBean {
         try {
             conn.setConnectTimeout(10000)
             conn.setReadTimeout(50000)
+            conn.setRequestProperty('User-Agent', grailsApplication.config.getProperty("customUserAgent", "ala-bie-hub"))
             def json = conn.content.text
             return JSON.parse(json)
         } catch (ConverterException e) {
@@ -143,7 +146,8 @@ class WebClientService implements InitializingBean {
         def conn = new URL(url).openConnection()
         try {
             conn.setDoOutput(true)
-            conn.setRequestProperty("Content-Type", contentType);
+            conn.setRequestProperty("Content-Type", contentType)
+            conn.setRequestProperty('User-Agent', grailsApplication.config.getProperty("customUserAgent", "ala-bie-hub"))
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream())
             wr.write(postBody)
             wr.flush()


### PR DESCRIPTION
#124

Tested locally against `bie-ws-test` and checked logs there - see:

`172.30.2.200 - - [09/Dec/2024:12:43:42 +1100] "GET /ws/search?q=turtle&start=0&rows=10&sort=&dir=desc&facets=idxtype,rank,speciesGroup,locatedInHubCountry,imageAvailable,conservationStatusAUS_s,conservationStatusACT_s,conservationStatusNSW_s,conservationStatusQLD_s,conservationStatusVIC_s,conservationStatusTAS_s,conservationStatusSA_s,conservationStatusWA_s,conservationStatusNT_s&q.op=OR HTTP/1.1" 200 10468 "-" "ala-bie-hub/4.2.0-SNAPSHOT" "140.253.238.151" request_time=0.048 upstream_response_time=0.048 upstream_connect_time=0.000 upstream_header_time=0.048 upstream_cache_status=-`